### PR TITLE
Explicitly import Buffer from "buffer"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib
 docs
+node_modules

--- a/src/bigint.ts
+++ b/src/bigint.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { blob, Layout } from '@solana/buffer-layout';
 import { toBigIntBE, toBigIntLE, toBufferBE, toBufferLE } from 'bigint-buffer';
 import { encodeDecode } from './base';


### PR DESCRIPTION
This removes the implicit assumption that a global `Buffer` variable is going to be present, which is dangerous and breaks some workflows, e.g. using native ESM in the browser with jspm.io

Could you please also publish a patch update to npm if this PR is accepted. I'm currently trying to use this library in Framer (https://framer.com/sites/npm) and this issue blocks me