### PR TITLE
Support modern TypeScript moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "types": "lib/types/index.d.ts",
     "exports": {
         "import": "./lib/esm/index.mjs",
-        "require": "./lib/cjs/index.js"
+        "require": "./lib/cjs/index.js",
+        "types": "./lib/types/index.d.ts"
     },
     "scripts": {
         "clean": "shx rm -rf lib",


### PR DESCRIPTION
With modern Typescript setup ("moduleResolution" set to "Node16" or "Bundler"), types don't work:

> Could not find a declaration file for module '@solana/buffer-layout-utils'. '/.../node_modules/.pnpm/@solana+buffer-layout-utils@0.2.0/node_modules/@solana/buffer-layout-utils/lib/esm/index.mjs' implicitly has an 'any' type.
>  There are types at '/.../node_modules/@solana/buffer-layout-utils/lib/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@solana/buffer-layout-utils' library may need to update its package.json or typings.ts(7016)

The PR adds a proper types exports section.